### PR TITLE
Fix: list comprehension scope bug

### DIFF
--- a/ispec/modeling/ssf.py
+++ b/ispec/modeling/ssf.py
@@ -949,7 +949,9 @@ def model_spectrum(spectrum, continuum_model, modeled_layers_pack, linelist, iso
     ]
 
     # Fetch the local variables by name
-    lengths = {name: len(locals()[name]) for name in names}
+    local_snapshot = dict(locals())
+    # ^ Create a snapshot of the locals (list comprehensions have their own scope in Python 3)
+    lengths = {name: len(local_snapshot[name]) for name in names}
 
     if len(set(lengths.values())) != 1:
         raise ValueError(f"Inconsistent lengths among inputs: {lengths}")


### PR DESCRIPTION
### ❗ Problem
This PR fixes an issue where `locals()` was used inside a list comprehension (in `modeling.ssf.model_spectrum`, where the script checks that all input variables have the same number of elements).

This issue was throwing `KeyError`s whenever the `model_spectrum` function was called, as list comprehensions have their own local scope (see [this Stack Overflow post](https://stackoverflow.com/questions/55084171/cant-use-locals-in-list-comprehension-in-python-3)) so it couldn't find any variables defined outside the comprehension.

### 🔧 Fix
The fix is very simple -- take a snapshot of the local variables before executing the list comprehension:
```
-    lengths = {name: len(locals()[name]) for name in names}

+    local_snapshot = dict(locals())
+    lengths = {name: len(local_snapshot[name]) for name in names}
```

With this change, the `model_spectrum` function runs fine. There are no necessary API changes or changes to other parts of the codebase.